### PR TITLE
make `wasm32-*` compatible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-targets --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,4 +19,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose --all-targets --all-features
+      run: |
+        cargo test --verbose
+        cargo test --verbose --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 
 [features]
 default = ["serde"]
-ssh = ["ssh-key", "ssh-encoding"]
 
 [dependencies]
 blsful = { version = "2.5", git = "https://github.com/mikelodder7/blsful.git" }
@@ -23,12 +22,19 @@ serde = { version = "1.0", default-features = false, features = [
   "alloc",
   "derive",
 ], optional = true }
+ssh-encoding = { version = "0.2" }
 thiserror = "1.0"
 unsigned-varint = { version = "0.8", features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ssh-key = { version = "0.6", default-features = false, features = [
+  "alloc",
+  "ecdsa",
+  "ed25519",
+] }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ssh-key = { version = "0.6", features = ["crypto"], optional = true }
-ssh-encoding = { version = "0.2", optional = true }
+ssh-key = { version = "0.6", features = ["crypto"] }
 
 [dev-dependencies]
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 
 [features]
 default = ["serde"]
+ssh = ["ssh-key", "ssh-encoding"]
 
 [dependencies]
 blsful = { version = "2.5", git = "https://github.com/mikelodder7/blsful.git" }
@@ -18,11 +19,16 @@ multibase = { version = "1.0", git = "https://github.com/cryptidtech/rust-multib
 multicodec = { version = "1.0", git = "https://github.com/cryptidtech/rust-multicodec.git" }
 multitrait = { version = "1.0", git = "https://github.com/cryptidtech/multitrait.git" }
 multiutil = { version = "1.0", git = "https://github.com/cryptidtech/multiutil.git" }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
-ssh-key = { version = "0.6", features = ["crypto"] }
-ssh-encoding = "0.2"
+serde = { version = "1.0", default-features = false, features = [
+  "alloc",
+  "derive",
+], optional = true }
 thiserror = "1.0"
 unsigned-varint = { version = "0.8", features = ["std"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ssh-key = { version = "0.6", features = ["crypto"], optional = true }
+ssh-encoding = { version = "0.2", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 // SPDX-License-Idnetifier: Apache-2.0
 /// Errors created by this library
 #[derive(Clone, Debug, thiserror::Error)]
@@ -125,12 +127,39 @@ pub enum SharesError {
 #[derive(Clone, Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ConversionsError {
-    /// Ssh signature conversion error
-    #[cfg(feature = "ssh")]
+    /// Ssh conversion error
     #[error(transparent)]
-    SshSig(#[from] ssh_key::Error),
-    /// Ssh label error
-    #[cfg(feature = "ssh")]
-    #[error(transparent)]
-    SshSigLabel(#[from] ssh_encoding::LabelError),
+    Ssh(#[from] SshError),
+}
+
+/// SSH Errors
+#[derive(Clone, Debug)]
+pub enum SshError {
+    /// SSH Sig
+    Sig(ssh_key::Error),
+    /// SSH Sig label
+    SigLabel(ssh_encoding::LabelError),
+}
+
+impl Display for SshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SshError::Sig(e) => write!(f, "SSH Sig error: {}", e),
+            SshError::SigLabel(e) => write!(f, "SSH Sig label error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for SshError {}
+
+impl From<ssh_key::Error> for SshError {
+    fn from(e: ssh_key::Error) -> Self {
+        SshError::Sig(e)
+    }
+}
+
+impl From<ssh_encoding::LabelError> for SshError {
+    fn from(e: ssh_encoding::LabelError) -> Self {
+        SshError::SigLabel(e)
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,9 +126,11 @@ pub enum SharesError {
 #[non_exhaustive]
 pub enum ConversionsError {
     /// Ssh signature conversion error
+    #[cfg(feature = "ssh")]
     #[error(transparent)]
     SshSig(#[from] ssh_key::Error),
     /// Ssh label error
+    #[cfg(feature = "ssh")]
     #[error(transparent)]
     SshSigLabel(#[from] ssh_encoding::LabelError),
 }

--- a/src/ms.rs
+++ b/src/ms.rs
@@ -254,7 +254,6 @@ impl Builder {
     }
 
     /// create new multisig from ssh Signature
-    #[cfg(feature = "ssh")]
     pub fn new_from_ssh_signature(sig: &ssh_key::Signature) -> Result<Self, Error> {
         let mut attributes = BTreeMap::new();
         use ssh_key::Algorithm::*;
@@ -603,7 +602,6 @@ mod tests {
         assert_eq!(ms1, ms3);
     }
 
-    #[cfg(feature = "ssh")]
     #[test]
     fn test_eddsa_ssh_roundtrip() {
         let ms1 = Builder::new(Codec::EddsaMsig)
@@ -619,7 +617,6 @@ mod tests {
         assert_eq!(ms1, ms2);
     }
 
-    #[cfg(feature = "ssh")]
     #[test]
     fn test_es256k_ssh_roundtrip() {
         let ms1 = Builder::new(Codec::Es256KMsig)
@@ -635,7 +632,6 @@ mod tests {
         assert_eq!(ms1, ms2);
     }
 
-    #[cfg(feature = "ssh")]
     #[test]
     fn test_bls_signature_ssh_roundtrip() {
         let sk = blsful::Bls12381G1::new_secret_key();
@@ -662,7 +658,6 @@ mod tests {
         assert_eq!(ms1, ms2);
     }
 
-    #[cfg(feature = "ssh")]
     #[test]
     fn test_bls_signature_combine_ssh_roundtrip() {
         let sk = blsful::Bls12381G2::new_secret_key();

--- a/src/ms.rs
+++ b/src/ms.rs
@@ -23,15 +23,15 @@ pub const SIG_CODECS: [Codec; 4] = [
     // Codec::Es384Msig,
     // Codec::Es521Msig,
     // Codec::Rs256Msig,
-    Codec::Es256KMsig//,
-    //Codec::LamportMsig,
+    Codec::Es256KMsig, //,
+                       //Codec::LamportMsig,
 ];
 
 /// the list of signature share codecs supported
 pub const SIG_SHARE_CODECS: [Codec; 2] = [
     Codec::Bls12381G1ShareMsig,
-    Codec::Bls12381G2ShareMsig//,
-    //Codec::LamportShareMsig,
+    Codec::Bls12381G2ShareMsig, //,
+                                //Codec::LamportShareMsig,
 ];
 
 /// the multisig sigil
@@ -254,6 +254,7 @@ impl Builder {
     }
 
     /// create new multisig from ssh Signature
+    #[cfg(feature = "ssh")]
     pub fn new_from_ssh_signature(sig: &ssh_key::Signature) -> Result<Self, Error> {
         let mut attributes = BTreeMap::new();
         use ssh_key::Algorithm::*;
@@ -602,6 +603,7 @@ mod tests {
         assert_eq!(ms1, ms3);
     }
 
+    #[cfg(feature = "ssh")]
     #[test]
     fn test_eddsa_ssh_roundtrip() {
         let ms1 = Builder::new(Codec::EddsaMsig)
@@ -617,6 +619,7 @@ mod tests {
         assert_eq!(ms1, ms2);
     }
 
+    #[cfg(feature = "ssh")]
     #[test]
     fn test_es256k_ssh_roundtrip() {
         let ms1 = Builder::new(Codec::Es256KMsig)
@@ -632,6 +635,7 @@ mod tests {
         assert_eq!(ms1, ms2);
     }
 
+    #[cfg(feature = "ssh")]
     #[test]
     fn test_bls_signature_ssh_roundtrip() {
         let sk = blsful::Bls12381G1::new_secret_key();
@@ -658,6 +662,7 @@ mod tests {
         assert_eq!(ms1, ms2);
     }
 
+    #[cfg(feature = "ssh")]
     #[test]
     fn test_bls_signature_combine_ssh_roundtrip() {
         let sk = blsful::Bls12381G2::new_secret_key();

--- a/src/views.rs
+++ b/src/views.rs
@@ -31,7 +31,6 @@ pub trait DataView {
 /// trait for converting Multisigs to other formats
 pub trait ConvView {
     /// convert the Multisig to an SSH signature
-    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error>;
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -31,6 +31,7 @@ pub trait DataView {
 /// trait for converting Multisigs to other formats
 pub trait ConvView {
     /// convert the Multisig to an SSH signature
+    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error>;
 }
 

--- a/src/views/bls12381.rs
+++ b/src/views/bls12381.rs
@@ -369,6 +369,7 @@ impl<'a> DataView for View<'a> {
 
 impl<'a> ConvView for View<'a> {
     /// convert to SSH signature format
+    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error> {
         // get the signature data
         let dv = self.ms.data_view()?;

--- a/src/views/bls12381.rs
+++ b/src/views/bls12381.rs
@@ -369,7 +369,6 @@ impl<'a> DataView for View<'a> {
 
 impl<'a> ConvView for View<'a> {
     /// convert to SSH signature format
-    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error> {
         // get the signature data
         let dv = self.ms.data_view()?;
@@ -387,11 +386,11 @@ impl<'a> ConvView for View<'a> {
                 Ok(ssh_key::Signature::new(
                     ssh_key::Algorithm::Other(
                         ssh_key::AlgorithmName::new(ALGORITHM_NAME_G1)
-                            .map_err(|e| ConversionsError::SshSigLabel(e))?,
+                            .map_err(|e| ConversionsError::Ssh(e.into()))?,
                     ),
                     sig_data,
                 )
-                .map_err(|e| ConversionsError::SshSig(e))?)
+                .map_err(|e| ConversionsError::Ssh(e.into()))?)
             }
             Codec::Bls12381G2Msig => {
                 // create the combined sig tuple
@@ -400,11 +399,11 @@ impl<'a> ConvView for View<'a> {
                 Ok(ssh_key::Signature::new(
                     ssh_key::Algorithm::Other(
                         ssh_key::AlgorithmName::new(ALGORITHM_NAME_G2)
-                            .map_err(|e| ConversionsError::SshSigLabel(e))?,
+                            .map_err(|e| ConversionsError::Ssh(e.into()))?,
                     ),
                     sig_data,
                 )
-                .map_err(|e| ConversionsError::SshSig(e))?)
+                .map_err(|e| ConversionsError::Ssh(e.into()))?)
             }
             Codec::Bls12381G1ShareMsig => {
                 // get the threshold attributes
@@ -420,11 +419,11 @@ impl<'a> ConvView for View<'a> {
                 Ok(ssh_key::Signature::new(
                     ssh_key::Algorithm::Other(
                         ssh_key::AlgorithmName::new(ALGORITHM_NAME_G1_SHARE)
-                            .map_err(|e| ConversionsError::SshSigLabel(e))?,
+                            .map_err(|e| ConversionsError::Ssh(e.into()))?,
                     ),
                     sig_data,
                 )
-                .map_err(|e| ConversionsError::SshSig(e))?)
+                .map_err(|e| ConversionsError::Ssh(e.into()))?)
             }
             Codec::Bls12381G2ShareMsig => {
                 // get the threshold attributes
@@ -440,11 +439,11 @@ impl<'a> ConvView for View<'a> {
                 Ok(ssh_key::Signature::new(
                     ssh_key::Algorithm::Other(
                         ssh_key::AlgorithmName::new(ALGORITHM_NAME_G2_SHARE)
-                            .map_err(|e| ConversionsError::SshSigLabel(e))?,
+                            .map_err(|e| ConversionsError::Ssh(e.into()))?,
                     ),
                     sig_data,
                 )
-                .map_err(|e| ConversionsError::SshSig(e))?)
+                .map_err(|e| ConversionsError::Ssh(e.into()))?)
             }
             _ => Err(Error::UnsupportedAlgorithm(self.ms.codec.to_string())),
         }

--- a/src/views/ed25519.rs
+++ b/src/views/ed25519.rs
@@ -50,14 +50,13 @@ impl<'a> DataView for View<'a> {
 
 impl<'a> ConvView for View<'a> {
     /// convert to SSH signature format
-    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error> {
         // get the signature data
         let dv = self.ms.data_view()?;
         let sig_bytes = dv.sig_bytes()?;
         Ok(
             ssh_key::Signature::new(ssh_key::Algorithm::Ed25519, sig_bytes)
-                .map_err(|e| ConversionsError::SshSig(e))?,
+                .map_err(|e| ConversionsError::Ssh(e.into()))?,
         )
     }
 }

--- a/src/views/ed25519.rs
+++ b/src/views/ed25519.rs
@@ -50,6 +50,7 @@ impl<'a> DataView for View<'a> {
 
 impl<'a> ConvView for View<'a> {
     /// convert to SSH signature format
+    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error> {
         // get the signature data
         let dv = self.ms.data_view()?;

--- a/src/views/secp256k1.rs
+++ b/src/views/secp256k1.rs
@@ -53,6 +53,7 @@ impl<'a> DataView for View<'a> {
 
 impl<'a> ConvView for View<'a> {
     /// convert to SSH signature format
+    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error> {
         // get the signature data
         let dv = self.ms.data_view()?;

--- a/src/views/secp256k1.rs
+++ b/src/views/secp256k1.rs
@@ -6,7 +6,7 @@ use crate::{
 use multicodec::Codec;
 
 /// the name used to identify these signatures in non-Multikey formats
-pub const ALGORITHM_NAME: &'static str = "secp256k1@multisig";
+pub const ALGORITHM_NAME: &str = "secp256k1@multisig";
 
 pub(crate) struct View<'a> {
     ms: &'a Multisig,
@@ -53,7 +53,6 @@ impl<'a> DataView for View<'a> {
 
 impl<'a> ConvView for View<'a> {
     /// convert to SSH signature format
-    #[cfg(feature = "ssh")]
     fn to_ssh_signature(&self) -> Result<ssh_key::Signature, Error> {
         // get the signature data
         let dv = self.ms.data_view()?;
@@ -61,10 +60,10 @@ impl<'a> ConvView for View<'a> {
         Ok(ssh_key::Signature::new(
             ssh_key::Algorithm::Other(
                 ssh_key::AlgorithmName::new(ALGORITHM_NAME)
-                    .map_err(|e| ConversionsError::SshSigLabel(e))?,
+                    .map_err(|e| ConversionsError::Ssh(e.into()))?,
             ),
             sig_bytes,
         )
-        .map_err(|e| ConversionsError::SshSig(e))?)
+        .map_err(|e| ConversionsError::Ssh(e.into()))?)
     }
 }


### PR DESCRIPTION
Current config does not allow for `wasm32-*` target builds.

This PR ~~puts `ssh-*` behind a `ssh` feature flag, and only for non-`wasm32` targets.~~ uses `ssh-key` without `default-features` to enable `wasm32` builds.

```toml
[target.'cfg(target_arch = "wasm32")'.dependencies]
ssh-key = { version = "0.6", default-features = false, features = [
  "alloc",
  "ecdsa",
  "ed25519",
] }

[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
ssh-key = { version = "0.6", features = ["alloc", "crypto", "ed25519"] }
```

Note that the `crypto` feature of `ssh-key` seems to still break `wasm32` builds (I'm looking at you, `p384`), but there are many algs that aren't being used so this feature is paired down to only the 2 that are used.